### PR TITLE
解决代理与非代理的情况，原始请求端口号的获取。以应对[Authorize]重定向登录页面后因端口号丢失而引发的错误

### DIFF
--- a/src/FilmHouse.App.Presentation.Web.UI/Controllers/AccountController.cs
+++ b/src/FilmHouse.App.Presentation.Web.UI/Controllers/AccountController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Security.Claims;
+using System.Web;
 using FilmHouse.App.Presentation.Web.UI.Models;
 using FilmHouse.Commands.Account;
 using FilmHouse.Core.DependencyInjection;
@@ -52,13 +53,13 @@ namespace FilmHouse.App.Presentation.Web.UI.Controllers
         [HttpGet]
         [AllowAnonymous]
         [LogonFilter]
-        public ActionResult Login(string transfer)
+        public ActionResult Login(string returnurl)
         {
             if (base.User.Identity.IsAuthenticated)
             {
                 return base.RedirectToAction("Index", "Mine");
             }
-            base.ViewBag.Transfer = transfer;
+            base.ViewBag.Transfer = !string.IsNullOrEmpty(returnurl) ? HttpUtility.UrlDecode(returnurl) : "/";
             return base.View();
         }
 
@@ -67,7 +68,7 @@ namespace FilmHouse.App.Presentation.Web.UI.Controllers
         [HttpPost]
         [AllowAnonymous]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Login(LoginViewModel model, string transfer)
+        public async Task<IActionResult> Login(LoginViewModel model, string returnurl)
         {
             try
             {
@@ -91,7 +92,8 @@ namespace FilmHouse.App.Presentation.Web.UI.Controllers
                         {
                             return base.RedirectToAction("Index", "Movie", new { Area = "Manage" });
                         }
-                        return this.RedirectToLocal(transfer);
+
+                        return this.RedirectToLocal(returnurl);
 
                     case Commands.Account.SignInStatus.UndefinedAccount:
                         base.ModelState.AddModelError("", "用户名不存在。");

--- a/tools/nginx-1.24.0/conf/nginx.conf
+++ b/tools/nginx-1.24.0/conf/nginx.conf
@@ -55,6 +55,9 @@ http {
         # (设置代理请求的`Host`头) 将原始请求的主机和服务器监听的端口信息传递给后端服务器
         proxy_set_header Host $host:$server_port;
 
+        # 设置 X-Forwarded-Port 头部
+        proxy_set_header X-Forwarded-Port $server_port;
+
         # (设置代理请求的自定义`Host`头)
         proxy_set_header X-XSRF-FILMHOUSE-TOKEN $http_x_xsrf-filmhouse-token;
 


### PR DESCRIPTION
（发生在反向代理后原始请求端口号丢失）